### PR TITLE
Correct the time incrementation for control recomputation

### DIFF
--- a/src/tools/device.cpp
+++ b/src/tools/device.cpp
@@ -299,7 +299,7 @@ increment( const double & dt )
 
 
   /* Force the recomputation of the control. */
-  controlSIN( time+1 );
+  controlSIN( time );
   sotDEBUG(25) << "u" <<time<<" = " << controlSIN.accessCopy() << endl;
 
   /* Integration of numerical values. This function is virtual. */


### PR DESCRIPTION
This modification allows to avoid a strange stairs shape of the control of the SoT (I don't understand where it comes from).
