### PR TITLE
Fix Task::computeTaskExponentialDecrease when using derivative.

### DIFF
--- a/src/task/task.cpp
+++ b/src/task/task.cpp
@@ -265,7 +265,7 @@ computeTaskExponentialDecrease( VectorMultiBound& errorRef,int time )
     {
       const dynamicgraph::Vector & de = errorTimeDerivativeSOUT(time);
       for( unsigned int i=0;i<errorRef.size(); ++i )
-	errorRef[i] = errorRef[i].getSingleBound() - de(i);
+	errorRef[i] = errorRef[i].getSingleBound() + de(i);
     }
 
   sotDEBUG(15) << "# Out }" << endl;


### PR DESCRIPTION
It fixes #41.