### PR TITLE
Adding gradient ascent and expoential average mean entity

### DIFF
--- a/include/sot/core/exp-moving-avg.hh
+++ b/include/sot/core/exp-moving-avg.hh
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018,
+ * Julian Viereck
+ *
+ * CNRS/AIST
+ *
+ * This file is part of sot-core.
+ * sot-core is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * sot-core is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with sot-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SOT_EXPMOVINGAVG_H__
+#define __SOT_EXPMOVINGAVG_H__
+
+/* --------------------------------------------------------------------- */
+/* --- INCLUDE --------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+#include <dynamic-graph/entity.h>
+#include <dynamic-graph/signal-ptr.h>
+#include <dynamic-graph/signal-time-dependent.h>
+
+namespace dg = ::dynamicgraph;
+
+namespace dynamicgraph {
+  namespace sot {
+
+/* --------------------------------------------------------------------- */
+/* --- API ------------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+#if defined (WIN32)
+#  if defined (reader_EXPORTS)
+#    define SOTEXPMOVINGAVG_EXPORT __declspec(dllexport)
+#  else
+#    define SOTEXPMOVINGAVG_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define SOTEXPMOVINGAVG_EXPORT
+#endif
+
+/* --------------------------------------------------------------------- */
+/* --- TRACER ---------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+using dynamicgraph::Entity;
+using dynamicgraph::SignalPtr;
+using dynamicgraph::SignalTimeDependent;
+
+class SOTEXPMOVINGAVG_EXPORT ExpMovingAvg
+: public Entity
+{
+  DYNAMIC_GRAPH_ENTITY_DECL();
+ public:
+
+  SignalPtr< dg::Vector,int > updateSIN;
+  SignalTimeDependent<int,int> refresherSINTERN;
+  SignalTimeDependent<dg::Vector,int> averageSOUT;
+
+ public:
+  ExpMovingAvg( const std::string& n );
+  virtual ~ExpMovingAvg( void );
+
+  void setAlpha(const double& alpha_);
+
+ protected:
+
+  dg::Vector& update(dg::Vector& res, const int& inTime);
+
+  dg::Vector average;
+
+  double alpha;
+  bool init;
+
+};
+
+  } /* namespace sot */
+} /* namespace dynamicgraph */
+
+#endif /* #ifndef __SOT_TRACER_H__ */
+
+

--- a/include/sot/core/exp-moving-avg.hh
+++ b/include/sot/core/exp-moving-avg.hh
@@ -24,6 +24,7 @@
 /* --- INCLUDE --------------------------------------------------------- */
 /* --------------------------------------------------------------------- */
 
+#include <sot/core/config.hh>
 #include <dynamic-graph/entity.h>
 #include <dynamic-graph/signal-ptr.h>
 #include <dynamic-graph/signal-time-dependent.h>
@@ -34,20 +35,6 @@ namespace dynamicgraph {
   namespace sot {
 
 /* --------------------------------------------------------------------- */
-/* --- API ------------------------------------------------------------- */
-/* --------------------------------------------------------------------- */
-
-#if defined (WIN32)
-#  if defined (reader_EXPORTS)
-#    define SOTEXPMOVINGAVG_EXPORT __declspec(dllexport)
-#  else
-#    define SOTEXPMOVINGAVG_EXPORT __declspec(dllimport)
-#  endif
-#else
-#  define SOTEXPMOVINGAVG_EXPORT
-#endif
-
-/* --------------------------------------------------------------------- */
 /* --- TRACER ---------------------------------------------------------- */
 /* --------------------------------------------------------------------- */
 
@@ -55,7 +42,7 @@ using dynamicgraph::Entity;
 using dynamicgraph::SignalPtr;
 using dynamicgraph::SignalTimeDependent;
 
-class SOTEXPMOVINGAVG_EXPORT ExpMovingAvg
+class SOT_CORE_DLLAPI ExpMovingAvg
 : public Entity
 {
   DYNAMIC_GRAPH_ENTITY_DECL();

--- a/include/sot/core/gradient-ascent.hh
+++ b/include/sot/core/gradient-ascent.hh
@@ -24,6 +24,7 @@
 /* --- INCLUDE --------------------------------------------------------- */
 /* --------------------------------------------------------------------- */
 
+#include <sot/core/config.hh>
 #include <dynamic-graph/entity.h>
 #include <dynamic-graph/signal-ptr.h>
 #include <dynamic-graph/signal-time-dependent.h>
@@ -34,20 +35,6 @@ namespace dynamicgraph {
   namespace sot {
 
 /* --------------------------------------------------------------------- */
-/* --- API ------------------------------------------------------------- */
-/* --------------------------------------------------------------------- */
-
-#if defined (WIN32)
-#  if defined (reader_EXPORTS)
-#    define SOTGRADIENTASCENT_EXPORT __declspec(dllexport)
-#  else
-#    define SOTGRADIENTASCENT_EXPORT __declspec(dllimport)
-#  endif
-#else
-#  define SOTGRADIENTASCENT_EXPORT
-#endif
-
-/* --------------------------------------------------------------------- */
 /* --- TRACER ---------------------------------------------------------- */
 /* --------------------------------------------------------------------- */
 
@@ -55,7 +42,7 @@ using dynamicgraph::Entity;
 using dynamicgraph::SignalPtr;
 using dynamicgraph::SignalTimeDependent;
 
-class SOTGRADIENTASCENT_EXPORT GradientAscent
+class SOT_CORE_DLLAPI GradientAscent
 : public Entity
 {
   DYNAMIC_GRAPH_ENTITY_DECL();

--- a/include/sot/core/gradient-ascent.hh
+++ b/include/sot/core/gradient-ascent.hh
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018,
+ * Julian Viereck
+ *
+ * CNRS/AIST
+ *
+ * This file is part of sot-core.
+ * sot-core is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * sot-core is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with sot-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SOT_GRADIENTASCENT_H__
+#define __SOT_GRADIENTASCENT_H__
+
+/* --------------------------------------------------------------------- */
+/* --- INCLUDE --------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+#include <dynamic-graph/entity.h>
+#include <dynamic-graph/signal-ptr.h>
+#include <dynamic-graph/signal-time-dependent.h>
+
+namespace dg = ::dynamicgraph;
+
+namespace dynamicgraph {
+  namespace sot {
+
+/* --------------------------------------------------------------------- */
+/* --- API ------------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+#if defined (WIN32)
+#  if defined (reader_EXPORTS)
+#    define SOTGRADIENTASCENT_EXPORT __declspec(dllexport)
+#  else
+#    define SOTGRADIENTASCENT_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define SOTGRADIENTASCENT_EXPORT
+#endif
+
+/* --------------------------------------------------------------------- */
+/* --- TRACER ---------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+using dynamicgraph::Entity;
+using dynamicgraph::SignalPtr;
+using dynamicgraph::SignalTimeDependent;
+
+class SOTGRADIENTASCENT_EXPORT GradientAscent
+: public Entity
+{
+  DYNAMIC_GRAPH_ENTITY_DECL();
+ public:
+
+  SignalPtr< dg::Vector,int > gradientSIN;
+  SignalPtr< double,int > learningRateSIN;
+  SignalTimeDependent<int,int> refresherSINTERN;
+  SignalTimeDependent<dg::Vector,int> valueSOUT;
+
+ public:
+  GradientAscent( const std::string& n );
+  virtual ~GradientAscent( void );
+
+ protected:
+
+  dg::Vector& update(dg::Vector& res, const int& inTime);
+
+  dg::Vector value;
+
+  double alpha;
+  bool init;
+
+};
+
+  } /* namespace sot */
+} /* namespace dynamicgraph */
+
+#endif /* #ifndef __SOT_TRACER_H__ */
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,8 @@ SET(plugins
   tools/joint-trajectory-entity
   tools/latch
   tools/switch
+  tools/exp-moving-avg
+  tools/gradient-ascent
 
   control/control-gr
   control/control-pd

--- a/src/dynamic_graph/sot/core/__init__.py
+++ b/src/dynamic_graph/sot/core/__init__.py
@@ -17,7 +17,5 @@ from math_small_entities import *
 from visual_point_projecter import VisualPointProjecter
 from feature_visual_point import FeatureVisualPoint
 from kalman import Kalman
-
-
-
-
+from exp_moving_avg import ExpMovingAvg
+from gradient_ascent import GradientAscent

--- a/src/tools/exp-moving-avg.cpp
+++ b/src/tools/exp-moving-avg.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018,
+ * Julian Viereck
+ *
+ * CNRS/AIST
+ *
+ * This file is part of sot-core.
+ * sot-core is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * sot-core is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with sot-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/function.hpp>
+
+#include <dynamic-graph/all-commands.h>
+#include <dynamic-graph/factory.h>
+
+#include <sot/core/factory.hh>
+#include <sot/core/exp-moving-avg.hh>
+
+namespace dg = ::dynamicgraph;
+
+/* ---------------------------------------------------------------------------*/
+/* ------- GENERIC HELPERS -------------------------------------------------- */
+/* ---------------------------------------------------------------------------*/
+
+namespace dynamicgraph {
+  namespace sot {
+
+
+DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN(ExpMovingAvg,"ExpMovingAvg");
+
+
+/* --------------------------------------------------------------------- */
+/* --- CLASS ----------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+
+ExpMovingAvg::
+ExpMovingAvg( const std::string& n )
+  :Entity(n)
+   ,updateSIN(NULL, "ExpMovingAvg(" + n + ")::input(vector)::update")
+   ,alpha(0.)
+   ,init(false)
+   ,refresherSINTERN( "ExpMovingAvg("+n+")::intern(dummy)::refresher"  )
+   ,averageSOUT(
+      boost::bind(&ExpMovingAvg::update,this,_1,_2),
+      updateSIN << refresherSINTERN, "ExpMovingAvg(" + n + ")::output(vector)::average")
+{
+  // Register signals into the entity.
+  signalRegistration(updateSIN << averageSOUT);
+  refresherSINTERN.setDependencyType( TimeDependency<int>::ALWAYS_READY );
+
+  std::string docstring;
+  // setAlpha
+  docstring =
+    "\n"
+    "    Set the alpha used to update the current value."
+    "\n";
+  addCommand(std::string("setAlpha"),
+	     new ::dynamicgraph::command::Setter<ExpMovingAvg, double>
+	     (*this, &ExpMovingAvg::setAlpha, docstring));
+}
+
+ExpMovingAvg::~ExpMovingAvg()
+{
+}
+
+/* --- COMPUTE ----------------------------------------------------------- */
+/* --- COMPUTE ----------------------------------------------------------- */
+/* --- COMPUTE ----------------------------------------------------------- */
+
+void ExpMovingAvg::setAlpha(const double& alpha_) {
+  assert(alpha <= 1. && alpha >= 0.);
+  alpha = alpha_;
+}
+
+dynamicgraph::Vector& ExpMovingAvg::update(dynamicgraph::Vector& res,
+						 const int& inTime)
+{
+  const dynamicgraph::Vector& update = updateSIN(inTime);
+
+  if (init == false) {
+    init = true;
+    average = update;
+    average.setZero();
+    res.resize(average.size());
+  }
+
+  res = average = alpha * average + (1. - alpha) * update;
+  return res;
+}
+
+
+
+  } /* namespace sot */
+} /* namespace dynamicgraph */

--- a/src/tools/gradient-ascent.cpp
+++ b/src/tools/gradient-ascent.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018,
+ * Julian Viereck
+ *
+ * CNRS/AIST
+ *
+ * This file is part of sot-core.
+ * sot-core is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * sot-core is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with sot-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/function.hpp>
+
+#include <dynamic-graph/all-commands.h>
+#include <dynamic-graph/factory.h>
+
+#include <sot/core/factory.hh>
+#include <sot/core/gradient-ascent.hh>
+
+namespace dg = ::dynamicgraph;
+
+/* ---------------------------------------------------------------------------*/
+/* ------- GENERIC HELPERS -------------------------------------------------- */
+/* ---------------------------------------------------------------------------*/
+
+namespace dynamicgraph {
+  namespace sot {
+
+
+DYNAMICGRAPH_FACTORY_ENTITY_PLUGIN(GradientAscent,"GradientAscent");
+
+
+/* --------------------------------------------------------------------- */
+/* --- CLASS ----------------------------------------------------------- */
+/* --------------------------------------------------------------------- */
+
+
+GradientAscent::
+GradientAscent( const std::string& n )
+  :Entity(n)
+   ,gradientSIN(NULL, "GradientAscent(" + n + ")::input(vector)::gradient")
+   ,learningRateSIN(NULL, "GradientAscent(" + n + ")::input(double)::learningRate")
+   ,init(false)
+   ,refresherSINTERN( "GradientAscent("+n+")::intern(dummy)::refresher"  )
+   ,valueSOUT(
+      boost::bind(&GradientAscent::update,this,_1,_2),
+      gradientSIN << refresherSINTERN, "GradientAscent(" + n + ")::output(vector)::value")
+{
+  // Register signals into the entity.
+  signalRegistration(gradientSIN << learningRateSIN << valueSOUT);
+  refresherSINTERN.setDependencyType( TimeDependency<int>::ALWAYS_READY );
+}
+
+GradientAscent::~GradientAscent()
+{
+}
+
+/* --- COMPUTE ----------------------------------------------------------- */
+/* --- COMPUTE ----------------------------------------------------------- */
+/* --- COMPUTE ----------------------------------------------------------- */
+
+dynamicgraph::Vector& GradientAscent::update(dynamicgraph::Vector& res,
+						 const int& inTime)
+{
+  const dynamicgraph::Vector& gradient = gradientSIN(inTime);
+  const double& learningRate = learningRateSIN(inTime);
+
+  if (init == false) {
+    init = true;
+    value = gradient;
+    value.setZero();
+    res.resize(value.size());
+  }
+
+  value += learningRate * gradient;
+  res = value;
+  return res;
+}
+
+  } /* namespace sot */
+} /* namespace dynamicgraph */


### PR DESCRIPTION
This implements two simple entity:
- `ExpMovingAvg`: An exponential moving average
- `GradientAscent`: A gradient ascent entity - given a gradient, it updates the current value by `+= dt * gradient`