### PR TITLE
fix build on C++11

### DIFF
--- a/src/tools/device.cpp
+++ b/src/tools/device.cpp
@@ -508,7 +508,7 @@ saturateBounds (double& val, const double& lower, const double& upper)
   for (int i = 0; i < val.size(); ++i) {                                       \
     double old = val(i);                                                       \
     if (saturateBounds (val(i), lower(i), upper(i)))                           \
-      dgRTLOG () << "Robot "what" bound violation at DoF " << i <<             \
+      dgRTLOG () << "Robot " what " bound violation at DoF " << i <<           \
       ": requested " << old << " but set " << val(i) << '\n';                  \
   }
 


### PR DESCRIPTION
```
src/tools/device.cpp:530:19: error: unable to find string literal operator ‘operator""what’ with ‘const char [31]’, ‘long unsigned int’ arguments
     CHECK_BOUNDS(state_, lowerPosition_, upperPosition_, "position");
                   ^
```