### PR TITLE
[Device] Fix device integrator, closes #105

### DIFF
--- a/src/tools/device.cpp
+++ b/src/tools/device.cpp
@@ -556,7 +556,6 @@ void Device::integrate( const double & dt )
 
   if (controlInputType_==CONTROL_INPUT_NO_INTEGRATION)
   {
-    assert(state_.size()==controlIN.size()+6);
     state_.tail(controlIN.size()) = controlIN;
     return;
   }
@@ -586,13 +585,16 @@ void Device::integrate( const double & dt )
     CHECK_BOUNDS(velocity_, lowerVelocity_, upperVelocity_, "velocity");
   }
 
-  // Freeflyer integration
   if (vel_control_.size() == state_.size()) {
+    // Freeflyer integration
     integrateRollPitchYaw(state_, vel_control_, dt);
+    // Joints integration
+    state_.tail(state_.size()-6) += vel_control_.tail(state_.size()-6) * dt;
   }
-
-  // Position integration
-  state_.tail(controlIN.size()) += vel_control_ * dt;
+  else{
+    // Position integration
+    state_.tail(controlIN.size()) += vel_control_ * dt;
+}
 
   // Position bounds check
   if (sanityCheck_) {


### PR DESCRIPTION
This fixes #105. I believe this change should be integrated and released as soon as possible.
I am not including unit tests, as @olivier-stasse told me he is making one.

Please note that this PR is made on top of the devel branch. The devel branch relies in turn on the not-yet-released devel branch of dynamic graph. Therefore, the CI will not pass as long as new release of dynamic-graph is made.

I believe the time is ready to make a new release of both dynamic graph and sot-core.

This is a quick fix to a serious bug, but I believe that the best long-term solution is to get rid of all this complications and just switch to Pinocchio's quaternions, so that we can just use Pinocchio's `integrate`, as mentioned by @florent-lamiraux in #105. See #88

