### PR TITLE
[SOT] Avoid exception when q0SIN is not plugged.

### DIFF
--- a/src/sot/sot.cpp
+++ b/src/sot/sot.cpp
@@ -472,15 +472,19 @@ computeControlLaw( dynamicgraph::Vector& control,const int& iterTime )
   const Matrix::Index mJ = K.cols(); // number dofs - number constraints
 
   if (q0SIN.isPlugged()) {
-    try {
-      control = q0SIN( iterTime );
-      sotDEBUG(15) << "initial velocity q0 = " << control << endl;
-      if( mJ!=control.size() )
-        control = Vector::Zero(mJ);
-    } catch (...) { // This catch is kept for backward compatibility.
-      control = Vector::Zero (mJ);
+    control = q0SIN( iterTime );
+    if (control.size() != mJ) {
+      std::ostringstream oss;
+      oss << "SOT(" + name() + "): q0SIN value length is " << control.size()
+        << "while the expected lenth is " << mJ;
+      throw std::length_error (oss.str());
     }
   } else {
+    if (stack.size() == 0) {
+      std::ostringstream oss;
+      oss << "SOT(" + name() + ") contains no task and q0SIN is not plugged.";
+      throw std::logic_error (oss.str());
+    }
     control = Vector::Zero (mJ);
     sotDEBUG(25) << "No initial velocity." <<endl;
   }

--- a/src/sot/sot.cpp
+++ b/src/sot/sot.cpp
@@ -471,17 +471,19 @@ computeControlLaw( dynamicgraph::Vector& control,const int& iterTime )
   const Matrix &K = constraintSOUT(iterTime);
   const Matrix::Index mJ = K.cols(); // number dofs - number constraints
 
-  try {
-    control = q0SIN( iterTime );
-    sotDEBUG(15) << "initial velocity q0 = " << control << endl;
-    if( mJ!=control.size() ) { control.resize( mJ ); control.setZero(); }
-  }
-  catch (...)
-    {
-      if( mJ!=control.size() ) { control.resize( mJ );}
-      control.setZero();
-      sotDEBUG(25) << "No initial velocity." <<endl;
+  if (q0SIN.isPlugged()) {
+    try {
+      control = q0SIN( iterTime );
+      sotDEBUG(15) << "initial velocity q0 = " << control << endl;
+      if( mJ!=control.size() )
+        control = Vector::Zero(mJ);
+    } catch (...) { // This catch is kept for backward compatibility.
+      control = Vector::Zero (mJ);
     }
+  } else {
+    control = Vector::Zero (mJ);
+    sotDEBUG(25) << "No initial velocity." <<endl;
+  }
 
   sotDEBUGF(5, " --- Time %d -------------------", iterTime );
   unsigned int iterTask = 0;


### PR DESCRIPTION
This avoids to throw an exception when not necessary. It is better for performances and for debugging. Otherwise, when catching exceptions with gdb, you get an exception at each iteration, which is very inconvenient.