### PR TITLE
[CMakeLists] Update dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ PKG_CONFIG_APPEND_LIBS("sot-core")
 SET(BOOST_COMPONENTS thread filesystem program_options unit_test_framework system regex )
 SEARCH_FOR_EIGEN()
 
-ADD_REQUIRED_DEPENDENCY("dynamic-graph >= 3.0.0")
+ADD_REQUIRED_DEPENDENCY("dynamic-graph >= 3.7.2")
 
 OPTION (BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 OPTION (INSTALL_PYTHON_INTERFACE_ONLY "Install *ONLY* the python binding" OFF)


### PR DESCRIPTION
Updating the dependency from `dynamic-graph` to the current apt release, `3.7.2`.

Notice that the current source release seems to be `3.7.3` (seen [here](https://github.com/stack-of-tasks/dynamic-graph/releases)).

We should probably also update the dependency from `dynamic-graph-python`, but I do not really understand the versioning for that package. The current version is `3.3.2`. Why is it different from the one of `dynamic-graph`?