### PR TITLE
Extend slightly parameter-server to fix sot-talos issues/24

### DIFF
--- a/include/sot/core/exception-tools.hh
+++ b/include/sot/core/exception-tools.hh
@@ -34,7 +34,8 @@ public:
 
     ,
     CORBA,
-    KALMAN_SIZE
+    KALMAN_SIZE,
+    PARAMETER_SERVER
   };
 
   static const std::string EXCEPTION_NAME;

--- a/include/sot/core/parameter-server.hh
+++ b/include/sot/core/parameter-server.hh
@@ -67,10 +67,10 @@ public:
             const std::string &robotRef);
 
   /// Initialize
-  /// The dtparam is found from ros_param
+  /// @param dt: control interval provided by the device.
   /// The urdf model is found by reading /robot_description
   /// The robot name is found using the name inside robot_description
-  void init_simple();
+  void init_simple(const double &dt);
   /* --- SIGNALS --- */
 
   /* --- COMMANDS --- */

--- a/include/sot/core/parameter-server.hh
+++ b/include/sot/core/parameter-server.hh
@@ -60,6 +60,8 @@ public:
   /* --- CONSTRUCTOR ---- */
   ParameterServer(const std::string &name);
 
+  ~ParameterServer() {};
+
   /// Initialize
   /// @param dt: control interval
   /// @param urdfFile: path to the URDF model of the robot

--- a/include/sot/core/parameter-server.hh
+++ b/include/sot/core/parameter-server.hh
@@ -66,6 +66,11 @@ public:
   void init(const double &dt, const std::string &urdfFile,
             const std::string &robotRef);
 
+  /// Initialize
+  /// The dtparam is found from ros_param
+  /// The urdf model is found by reading /robot_description
+  /// The robot name is found using the name inside robot_description
+  void init_simple();
   /* --- SIGNALS --- */
 
   /* --- COMMANDS --- */

--- a/include/sot/core/robot-utils.hh
+++ b/include/sot/core/robot-utils.hh
@@ -246,6 +246,7 @@ RobotUtilShrPtr RefVoidRobotUtil();
 RobotUtilShrPtr getRobotUtil(std::string &robotName);
 bool isNameInRobotUtil(std::string &robotName);
 RobotUtilShrPtr createRobotUtil(std::string &robotName);
+std::shared_ptr< std::vector<std::string> > getListOfRobots();
 
 bool base_se3_to_sot(ConstRefVector pos, ConstRefMatrix R, RefVector q_sot);
 

--- a/src/tools/parameter-server.cpp
+++ b/src/tools/parameter-server.cpp
@@ -154,7 +154,7 @@ void ParameterServer::init_simple(const double & dt) {
   m_emergency_stop_triggered = false;
   m_initSucceeded = true;
 
-  std::string localName;
+  std::string localName("robot");
   std::shared_ptr< std::vector<std::string> >
       listOfRobots = sot::getListOfRobots();
 
@@ -196,11 +196,6 @@ void ParameterServer::init(const double &dt, const std::string &urdfFile,
 
   m_robot_util->m_urdf_filename = urdfFile;
 
-  addCommand(
-      "getJointsUrdfToSot",
-      makeDirectGetter(*this, &m_robot_util->m_dgv_urdf_to_sot,
-                       docDirectSetter("Display map Joints From URDF to SoT.",
-                                       "Vector of integer for mapping")));
 }
 
 /* ------------------------------------------------------------------- */

--- a/src/tools/parameter-server.cpp
+++ b/src/tools/parameter-server.cpp
@@ -60,6 +60,9 @@ ParameterServer::ParameterServer(const std::string &name)
                                               "Time period in seconds (double)",
                                               "URDF file path (string)",
                                               "Robot reference (string)")));
+  addCommand("init_simple",
+             makeCommandVoid0(*this, &ParameterServer::init_simple,
+                              docCommandVoid0("Initialize the entity.")));
 
   addCommand("setNameToId",
              makeCommandVoid2(*this, &ParameterServer::setNameToId,
@@ -136,6 +139,39 @@ ParameterServer::ParameterServer(const std::string &name)
                                      "Return the parameter value for parameter"
                                      " named ParameterName.",
                                      "(string) ParameterName")));
+}
+
+void ParameterServer::init_simple() {
+
+  m_emergency_stop_triggered = false;
+  m_initSucceeded = true;
+
+  std::string localName;
+  std::shared_ptr< std::vector<std::string> >
+      listOfRobots = sot::getListOfRobots();
+
+  std::cerr << "listOfRobots.size()="
+            << listOfRobots->size()
+            << std::endl;
+  
+  if (listOfRobots->size()==1)
+    localName = (*listOfRobots)[0];
+
+  std::cerr << "localName" << localName.c_str()
+            << std::endl;
+  
+  if (!isNameInRobotUtil(localName)) {
+    m_robot_util = createRobotUtil(localName);
+  } else {
+    m_robot_util = getRobotUtil(localName);
+  }
+
+  addCommand(
+      "getJointsUrdfToSot",
+      makeDirectGetter(*this, &m_robot_util->m_dgv_urdf_to_sot,
+                       docDirectSetter("Display map Joints From URDF to SoT.",
+                                       "Vector of integer for mapping")));
+
 }
 
 void ParameterServer::init(const double &dt, const std::string &urdfFile,

--- a/src/tools/robot-utils.cpp
+++ b/src/tools/robot-utils.cpp
@@ -438,6 +438,21 @@ bool base_sot_to_urdf(ConstRefVector q_sot, RefVector q_urdf) {
 
 std::map<std::string, RobotUtilShrPtr> sgl_map_name_to_robot_util;
 
+std::shared_ptr<std::vector<std::string> >  getListOfRobots() {
+  std::shared_ptr<std::vector<std::string> > res =
+      std::make_shared<std::vector<std::string> >();
+  
+  std::map<std::string, RobotUtilShrPtr>::iterator it =
+      sgl_map_name_to_robot_util.begin();
+  while (it != sgl_map_name_to_robot_util.end())
+  {
+    res->push_back(it->first);
+    it++;
+  }
+  
+  return res;
+}
+
 RobotUtilShrPtr getRobotUtil(std::string &robotName) {
   std::map<std::string, RobotUtilShrPtr>::iterator it =
       sgl_map_name_to_robot_util.find(robotName);


### PR DESCRIPTION
In order to fix https://github.com/stack-of-tasks/sot-talos/issues/24 this PR introduces:
  * A new method called init_simple to initialize the robot parameters. It assumes that there is already an entry for the robot model in the robot-utils instances.(for instance by calling parameter_server_read_description() during loading)
 * A instance of the destructor.