### PR TITLE
Fix warnings

### DIFF
--- a/include/sot/core/robot-utils.hh
+++ b/include/sot/core/robot-utils.hh
@@ -305,6 +305,7 @@ public:
           << " for get_parameter(" << parameter_name << ")\n"
           << e.what() << std::endl;
       sendMsg(oss.str(), MSG_TYPE_ERROR);
+      return 0;
     }
   }
   /** @} */


### PR DESCRIPTION
Fix warnings:
`In file included from /home/rascof/sot-core/include/sot/core/parameter-server.hh:42:0,
                 from /home/rascof/sot-core/src/tools/parameter-server.cpp:39:
/home/rascof/sot-core/include/sot/core/robot-utils.hh: In member function ‘Type dynamicgraph::sot::RobotUtil::get_parameter(const string&) [with Type = bool]’:
/home/rascof/sot-core/include/sot/core/robot-utils.hh:309:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
/home/rascof/sot-core/include/sot/core/robot-utils.hh: In member function ‘Type dynamicgraph::sot::RobotUtil::get_parameter(const string&) [with Type = double]’:
/home/rascof/sot-core/include/sot/core/robot-utils.hh:309:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
/home/rascof/sot-core/include/sot/core/robot-utils.hh: In member function ‘Type dynamicgraph::sot::RobotUtil::get_parameter(const string&) [with Type = int]’:
/home/rascof/sot-core/include/sot/core/robot-utils.hh:309:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
/home/rascof/sot-core/include/sot/core/robot-utils.hh: In member function ‘Type dynamicgraph::sot::RobotUtil::get_parameter(const string&) [with Type = std::__cxx11::basic_string<char>]’:
/home/rascof/sot-core/include/sot/core/robot-utils.hh:309:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
`