### PR TITLE
Fix warnings

### DIFF
--- a/include/sot/core/parameter-server.hh
+++ b/include/sot/core/parameter-server.hh
@@ -118,7 +118,7 @@ public:
       DYNAMIC_GRAPH_ENTITY_WARNING(*this)
           << "Cannot get parameter " << ParameterName
           << " before initialization!\n";
-      Type ParameterValue;
+      Type ParameterValue=Type();
       return ParameterValue;
     }
     return m_robot_util->get_parameter<Type>(ParameterName);


### PR DESCRIPTION
Fix warnings:
`sot-core/include/sot/core/parameter-server.hh: In member function ‘Type dynamicgraph::sot::ParameterServer::getParameter(const string&) [with Type = bool]’:
sot-core/include/sot/core/parameter-server.hh:123:14: warning: ‘ParameterValue’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       return ParameterValue;
              ^~~~~~~~~~~~~~
sot-core/include/sot/core/parameter-server.hh: In member function ‘Type dynamicgraph::sot::ParameterServer::getParameter(const string&) [with Type = double]’:
sot-core/include/sot/core/parameter-server.hh:123:14: warning: ‘ParameterValue’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       return ParameterValue;
              ^~~~~~~~~~~~~~
sot-core/include/sot/core/parameter-server.hh: In member function ‘Type dynamicgraph::sot::ParameterServer::getParameter(const string&) [with Type = int]’:
sot-core/include/sot/core/parameter-server.hh:123:14: warning: ‘ParameterValue’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       return ParameterValue;
              ^~~~~~~~~~~~~~
`