### PR TITLE
[Fix] CMake error fix on the ROS build farm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,9 @@ FOREACH(plugin ${plugins})
   TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${PROJECT_NAME} ${${LIBRARY_NAME}_deps})
 
   IF(NOT INSTALL_PYTHON_INTERFACE_ONLY)
+    IF(EXISTS "/tmp/ws/build_isolated/catkin_make_isolated.cache") # Relocate the Dynamic-graph plugin to fix a CMake error only in ROS release configuration
+      SET(DYNAMIC_GRAPH_PLUGINDIR "lib/dynamic-graph-plugin")
+    ENDIF(EXISTS "/tmp/ws/build_isolated/catkin_make_isolated.cache") # It should not affect the build from source
     INSTALL(TARGETS ${LIBRARY_NAME} EXPORT ${TARGETS_EXPORT_NAME}
       DESTINATION ${DYNAMIC_GRAPH_PLUGINDIR})
   ENDIF(NOT INSTALL_PYTHON_INTERFACE_ONLY)


### PR DESCRIPTION
Try to fix this error:
```
CMake Error at src/cmake_install.cmake:55 (file):
  file INSTALL cannot copy file
  "/tmp/ws/build_isolated/sot-core/install/src/libsot.so.4.10.1" to
  "/opt/ros/noetic/lib/dynamic-graph-plugins/libsot.so.4.10.1": Permission
  denied.
Call Stack (most recent call first):
  cmake_install.cmake:468 (include)


make: *** [Makefile:121: install] Error 1
<== Failed to process package 'sot-core': 
  Command '['make', 'install']' returned non-zero exit status 2.

Reproduce this error by running:
==> cd /tmp/ws/build_isolated/sot-core && make install

Command failed, exiting.
```