### PR TITLE
[tests] Fix the -ltracer not found by depending on the exported target.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,9 +17,7 @@ SET(TEST_tsot_LIBS
   gain-adaptive
   )
 
-LINK_DIRECTORIES(${DYNAMIC_GRAPH_PLUGINDIR})
-
-SET(TEST_test_traces_EXT_LIBS tracer)
+SET(TEST_test_traces_EXT_LIBS dynamic-graph::tracer)
 
 SET(TEST_test_gain_LIBS
   gain-adaptive feature-visual-point)
@@ -109,8 +107,6 @@ IF(UNIX)
     pluginabstract ${CMAKE_DL_LIBS})
 ENDIF(UNIX)
 
-# find -ltracer. TODO: that's ugly, properly export a component for each plugin instead.
-LINK_DIRECTORIES("${dynamic-graph_DIR}/../../../${DYNAMIC_GRAPH_PLUGINDIR}")
 FOREACH(path ${tests})
   GET_FILENAME_COMPONENT(test ${path} NAME)
   ADD_UNIT_TEST(${test} ${path}.cpp)


### PR DESCRIPTION
I ran into a compilation issue with the sot-core unit-tests concerning the dependency on the tracer.
One tests (or several) had this `-ltarget` as dependency which could not be found for some reasons.

So looking at the dynamic-graph package it appears that the plugin is properly exported.
So now the unit-tests depends on `dynamic-gaph::tracer` instead of `tracer`

Let me know what you think.