### PR TITLE
[tests] rename data do disambiguate for C++17

### DIFF
--- a/tests/signal/test_signal.cpp
+++ b/tests/signal/test_signal.cpp
@@ -26,31 +26,31 @@ public:
   }
 };
 
-dynamicgraph::Vector data(6);
+dynamicgraph::Vector test_data(6);
 Signal<dynamicgraph::Vector, double> sig("sigtest");
 DummyClass dummy;
 
 dynamicgraph::Vector &fun(dynamicgraph::Vector &res, double /*j*/) {
-  return res = data;
+  return res = test_data;
 }
 
 int main(void) {
-  data.fill(1);
-  cout << "data: " << data << endl;
+  test_data.fill(1);
+  cout << "test_data: " << test_data << endl;
 
-  sig.setConstant(data);
+  sig.setConstant(test_data);
   cout << "Constant: " << sig.access(1.) << endl;
-  data *= 2;
+  test_data *= 2;
   cout << "Constant: " << sig(1.) << endl;
 
-  sig.setReference(&data);
+  sig.setReference(&test_data);
   cout << "Reference: " << sig(1.) << endl;
-  data *= 2;
+  test_data *= 2;
   cout << "Reference: " << sig(1.) << endl;
 
   sig.setFunction(&fun);
   cout << "Function: " << sig(1.) << endl;
-  data *= 2;
+  test_data *= 2;
   cout << "Function: " << sig(1.) << endl;
 
   // boost::function2<int,int,double> onClick = (&DummyClass::fun, &dummy,
@@ -58,12 +58,12 @@ int main(void) {
   // &dummy);
   sig.setFunction(boost::bind(&DummyClass::fun, &dummy, _1, _2));
   cout << "Function: " << sig(1.5) << endl;
-  data *= 2;
+  test_data *= 2;
   cout << "Function: " << sig(1.34) << endl;
 
   //   sig.setFunction(&DummyClass::fun, dummy);
   //   cout << "Function: " << sig(1.5) <<endl;
-  //   data*=2;
+  //   test_data*=2;
   //   cout << "Function: " << sig(12.34) <<endl;
 
   return 0;


### PR DESCRIPTION
fix:

```
/root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp: In function ‘dynamicgraph::Vector& fun(dynamicgraph::Vector&, double)’:
/root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp:34:16: error: reference to ‘data’ is ambiguous
   34 |   return res = data;
      |                ^~~~ 
In file included from /usr/include/c++/11/string:54,
                 from /opt/openrobots/include/dynamic-graph/exception-abstract.h:8,
                 from /opt/openrobots/include/dynamic-graph/exception-signal.h:10,
                 from /opt/openrobots/include/dynamic-graph/signal-ptr.h:9,
                 from /opt/openrobots/include/dynamic-graph/all-signals.h:11,
                 from /root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp:13:

/usr/include/c++/11/bits/range_access.h:319:5: note: candidates are: ‘template<class _Tp> constexpr const _Tp* std::data(std::initializer_list<_Tp>)’
319 |     data(initializer_list<_Tp> __il) noexcept
    |     ^~~~
/usr/include/c++/11/bits/range_access.h:310:5: note:                 ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::data(_Tp (&)[_Nm])’
310 |     data(_Tp (&__array)[_Nm]) noexcept
    |     ^~~~
/usr/include/c++/11/bits/range_access.h:300:5: note:                 ‘template<class _Container> constexpr decltype (__cont.data()) std::data(const _Container&)’
300 |     data(const _Container& __cont) noexcept(noexcept(__cont.data()))
    |     ^~~~
/usr/include/c++/11/bits/range_access.h:290:5: note:                 ‘template<class _Container> constexpr decltype (__cont.data()) std::data(_Container&)’
290 |     data(_Container& __cont) noexcept(noexcept(__cont.data()))
    |     ^~~~
/root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp:29:22: note:                 ‘dynamicgraph::Vector data’
29 | dynamicgraph::Vector data(6);
   |                      ^~~~
/root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp: In function ‘int main()’:
/root/robotpkg/wip/sot-core-v3/work/sot-core-4.11.6/tests/signal/test_signal.cpp:38:3: error: reference to ‘data’ is ambiguous
   38 |   data.fill(1);
      |   ^~~~
 ```