### PR TITLE
[Device] relax test on dimension of state signal.

### DIFF
--- a/src/tools/device.cpp
+++ b/src/tools/device.cpp
@@ -260,11 +260,11 @@ void Device::setState(const Vector &st) {
           // fall through
         }
       case CONTROL_INPUT_ONE_INTEGRATION:
-        if (s != lowerVelocity_.size() || s != upperVelocity_.size()) {
+        if (s > lowerVelocity_.size() || s > upperVelocity_.size()) {
           std::ostringstream os;
           os << "dynamicgraph::sot::Device::setState: upper and/or lower "
                 "velocity"
-                " bounds do not match state size. Input State size = "
+                " bounds should be less than state size. Input State size = "
              << st.size()
              << ", lowerVelocity_.size() = " << lowerVelocity_.size()
              << ", upperVelocity_.size() = " << upperVelocity_.size()


### PR DESCRIPTION
  On franka robots, the gripper is not controlled via the SoT. As a consequence,
  the configuration vector is of dimension 7, while the dynamic entity reads the
  model via ROS and expects a position input signal of dimension 8: (7 arm
  joints + 2 gripper joints - 1 mimic joint).