### PR TITLE
[AbstractSotExternalInterface] Add parameter period in method getControl

### DIFF
--- a/include/sot/core/abstract-sot-external-interface.hh
+++ b/include/sot/core/abstract-sot-external-interface.hh
@@ -52,7 +52,12 @@ class SOT_CORE_EXPORT AbstractSotExternalInterface {
   virtual void cleanupSetSensors(
       std::map<std::string, SensorValues> &sensorsIn) = 0;
 
-  virtual void getControl(std::map<std::string, ControlValues> &) = 0;
+  // Get control vector
+  // \param map map string to vector of doubles. This method is expected to
+  //        fill in entry "control"
+  // \param period time since last call.
+  virtual void getControl(std::map<std::string, ControlValues> &,
+                          const double&) = 0;
   virtual void setSecondOrderIntegration(void) = 0;
   virtual void setNoIntegration(void) = 0;
 };

--- a/include/sot/core/abstract-sot-external-interface.hh
+++ b/include/sot/core/abstract-sot-external-interface.hh
@@ -57,7 +57,7 @@ class SOT_CORE_EXPORT AbstractSotExternalInterface {
   //        fill in entry "control"
   // \param period time since last call.
   virtual void getControl(std::map<std::string, ControlValues> &,
-                          const double &) = 0;
+                          const double &period = 0) = 0;
   virtual void setSecondOrderIntegration(void) = 0;
   virtual void setNoIntegration(void) = 0;
 };

--- a/include/sot/core/abstract-sot-external-interface.hh
+++ b/include/sot/core/abstract-sot-external-interface.hh
@@ -57,7 +57,7 @@ class SOT_CORE_EXPORT AbstractSotExternalInterface {
   //        fill in entry "control"
   // \param period time since last call.
   virtual void getControl(std::map<std::string, ControlValues> &,
-                          const double&) = 0;
+                          const double &) = 0;
   virtual void setSecondOrderIntegration(void) = 0;
   virtual void setNoIntegration(void) = 0;
 };

--- a/include/sot/core/sot-loader.hh
+++ b/include/sot/core/sot-loader.hh
@@ -120,7 +120,7 @@ class SotLoader {
   /// \param period time since last call
   void oneIteration(std::map<std::string, SensorValues> &sensors_in,
                     std::map<std::string, ControlValues> &control_values,
-                    const double& period);
+                    const double &period);
 
   /// \brief Load the Device entity in the python global scope.
   void loadDeviceInPython(const std::string &device_name);

--- a/include/sot/core/sot-loader.hh
+++ b/include/sot/core/sot-loader.hh
@@ -117,8 +117,10 @@ class SotLoader {
 
   /// \brief Compute one iteration of control.
   /// Basically executes fillSensors, the SoT and the readControl.
+  /// \param period time since last call
   void oneIteration(std::map<std::string, SensorValues> &sensors_in,
-                    std::map<std::string, ControlValues> &control_values);
+                    std::map<std::string, ControlValues> &control_values,
+                    const double& period);
 
   /// \brief Load the Device entity in the python global scope.
   void loadDeviceInPython(const std::string &device_name);

--- a/src/tools/sot-loader.cpp
+++ b/src/tools/sot-loader.cpp
@@ -171,7 +171,7 @@ void SotLoader::runPythonCommand(const std::string &command,
 void SotLoader::oneIteration(
     std::map<std::string, SensorValues> &sensors_in,
     std::map<std::string, ControlValues> &control_values,
-    const double& period) {
+    const double &period) {
   if (!dynamic_graph_stopped_) {
     try {
       sot_external_interface_->nominalSetSensors(sensors_in);

--- a/src/tools/sot-loader.cpp
+++ b/src/tools/sot-loader.cpp
@@ -170,11 +170,12 @@ void SotLoader::runPythonCommand(const std::string &command,
 
 void SotLoader::oneIteration(
     std::map<std::string, SensorValues> &sensors_in,
-    std::map<std::string, ControlValues> &control_values) {
+    std::map<std::string, ControlValues> &control_values,
+    const double& period) {
   if (!dynamic_graph_stopped_) {
     try {
       sot_external_interface_->nominalSetSensors(sensors_in);
-      sot_external_interface_->getControl(control_values);
+      sot_external_interface_->getControl(control_values, period);
     } catch (std::exception &e) {
       std::cout << "Exception while running the graph:\n"
                 << e.what() << std::endl;

--- a/tests/tools/dummy-sot-external-interface.cc
+++ b/tests/tools/dummy-sot-external-interface.cc
@@ -35,7 +35,8 @@ void DummySotExternalInterface::cleanupSetSensors(
 }
 
 void DummySotExternalInterface::getControl(
-    std::map<std::string, dynamicgraph::sot::ControlValues> &controlOut) {
+    std::map<std::string, dynamicgraph::sot::ControlValues> &controlOut,
+    const double &) {
   controlOut["ctrl_map_name"] = dynamicgraph::sot::ControlValues();
   controlOut["ctrl_map_name"].setName("ctrl_value_name");
   controlOut["ctrl_map_name"].setValues(std::vector<double>(5, 3.1415));

--- a/tests/tools/dummy-sot-external-interface.hh
+++ b/tests/tools/dummy-sot-external-interface.hh
@@ -32,7 +32,7 @@ class DummySotExternalInterface
 
   virtual void getControl(
       std::map<std::string, dynamicgraph::sot::ControlValues> &controlOut,
-      const double&);
+      const double &);
   virtual void setSecondOrderIntegration(void);
   virtual void setNoIntegration(void);
 

--- a/tests/tools/dummy-sot-external-interface.hh
+++ b/tests/tools/dummy-sot-external-interface.hh
@@ -31,7 +31,8 @@ class DummySotExternalInterface
       std::map<std::string, dynamicgraph::sot::SensorValues> &sensorsIn);
 
   virtual void getControl(
-      std::map<std::string, dynamicgraph::sot::ControlValues> &controlOut);
+      std::map<std::string, dynamicgraph::sot::ControlValues> &controlOut,
+      const double&);
   virtual void setSecondOrderIntegration(void);
   virtual void setNoIntegration(void);
 

--- a/tests/tools/test_sot_loader.cpp
+++ b/tests/tools/test_sot_loader.cpp
@@ -115,12 +115,12 @@ BOOST_FIXTURE_TEST_CASE(test_sot_loader_one_iteration, TestFixture) {
   sot_loader.setDynamicLibraryName(asotei_lib_file_);
   sot_loader.initialization();
   // Without running the graph:
-  sot_loader.oneIteration(sensors, controls);
+  sot_loader.oneIteration(sensors, controls, 1e-3);
   BOOST_CHECK(controls.find("ctrl_map_name") == controls.end());
   // With the graph running:
   sot_loader.startDG();
   std::cout << "running the graph" << std::endl;
-  sot_loader.oneIteration(sensors, controls);
+  sot_loader.oneIteration(sensors, controls, 1e-3);
   std::cout << "running the graph ... done" << std::endl;
   controls_values = controls["ctrl_map_name"].getValues();
   BOOST_CHECK_EQUAL(controls_values.size(), 5);


### PR DESCRIPTION

  When realtime is not correctly enforced, it may be usefull for the control law
  to be informed of the time to last call.